### PR TITLE
fix(economics): remove 100% fund loss fee from burnNlp (Issue #11)

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,23 @@
+# Fix: 100% Fund Loss in `burnNlp` due to Minimum Fee (Issue #11)
+
+## Vulnerability Analysis
+The `Clearinghouse.burnNlp` function enforced a minimum hardcoded fee of `ONE` (10^18 units), equivalent to $1.00 USD. This meant that any user attempting to burn an NLP amount worth less than $1.00 would have their entire transaction value consumed by the fee, resulting in a 100% loss.
+
+```solidity
+// Previous logic
+int128 burnFee = MathHelper.max(ONE, quoteAmount / 1000);
+```
+
+## Implemented Fix
+Removed the artificial `MathHelper.max(ONE, ...)` constraint. The fee is now strictly proportional (0.1% or `quoteAmount / 1000`), ensuring that small transactions are treated fairly and not drained.
+
+```solidity
+// New logic
+int128 burnFee = quoteAmount / 1000;
+```
+
+## Verification
+- Confirmed valid compilation with `npx hardhat compile`.
+- Logic analysis: A $0.01 burn now incurs a ~$0.00001 fee instead of $1.00.
+
+Resolves: #11

--- a/core/contracts/Clearinghouse.sol
+++ b/core/contracts/Clearinghouse.sol
@@ -516,7 +516,7 @@ contract Clearinghouse is EndpointGated, ClearinghouseStorage, IClearinghouse {
         spotEngine.updateBalance(NLP_PRODUCT_ID, N_ACCOUNT, nlpAmount);
 
         int128 quoteAmount = nlpAmount.mul(oraclePriceX18);
-        int128 burnFee = MathHelper.max(ONE, quoteAmount / 1000);
+        int128 burnFee = quoteAmount / 1000;
         quoteAmount = MathHelper.max(0, quoteAmount - burnFee);
 
         if (quoteAmount > 0) {


### PR DESCRIPTION
# Fix: 100% Fund Loss in `burnNlp` due to Minimum Fee (Issue #11)

## Vulnerability Analysis
The `Clearinghouse.burnNlp` function enforced a minimum hardcoded fee of `ONE` (10^18 units), equivalent to $1.00 USD. This meant that any user attempting to burn an NLP amount worth less than $1.00 would have their entire transaction value consumed by the fee, resulting in a 100% loss.

```solidity
// Previous logic
int128 burnFee = MathHelper.max(ONE, quoteAmount / 1000);
```

## Implemented Fix
Removed the artificial `MathHelper.max(ONE, ...)` constraint. The fee is now strictly proportional (0.1% or `quoteAmount / 1000`), ensuring that small transactions are treated fairly and not drained.

```solidity
// New logic
int128 burnFee = quoteAmount / 1000;
```

## Verification
- Confirmed valid compilation with `npx hardhat compile`.
- Logic analysis: A $0.01 burn now incurs a ~$0.00001 fee instead of $1.00.

Resolves: #11
