### PR TITLE
fix: correct misleading comment on max function in MathHelper

### DIFF
--- a/core/contracts/libraries/MathHelper.sol
+++ b/core/contracts/libraries/MathHelper.sol
@@ -7,7 +7,7 @@ import "./MathSD21x18.sol";
 library MathHelper {
     using MathSD21x18 for int128;
 
-    /// @notice Returns market id for two given product ids
+    /// @notice Returns the maximum of two int128 values
     function max(int128 a, int128 b) internal pure returns (int128) {
         return a > b ? a : b;
     }


### PR DESCRIPTION
## Problem

The comment for the `max` function in `MathHelper.sol` (line 10) incorrectly states "Returns market id for two given product ids". The function actually returns the maximum of two `int128` values. This is a clear copy-paste error from another function.

## Fix

Updated the NatSpec comment to accurately describe what the function does: "Returns the maximum of two int128 values".

## Why this is safe

This is a documentation-only change (comment fix). No code logic is modified. The change is minimal (one line) and makes the comment match the actual implementation.